### PR TITLE
add native toolchain definition to connector metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,9 +1177,12 @@ dependencies = [
  "anyhow",
  "build-data",
  "clap",
+ "insta",
  "ndc-bigquery-configuration",
  "serde",
+ "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror",
  "tokio",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,5 +20,10 @@ tokio = { workspace = true, features = ["full"] }
 [build-dependencies]
 build-data = { workspace = true }
 
+[dev-dependencies]
+insta = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+
 [package.metadata.cargo-machete]
 ignored = ["build_data", "build-data"] # apparently cargo-machete doesn't find dependencies used by build scripts

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -136,12 +136,12 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
             native_toolchain_definition: Some(metadata::NativeToolchainDefinition {
                 commands: vec![
                     ("start".to_string(), metadata::CommandDefinition::ShellScript {
-                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\nHASURA_CONFIGURATION_DIRECTORY=\"$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\" ndc-bigquery serve".to_string(),
-                        powershell: "$ErrorActionPreference = \"Stop\"\n$env:HASURA_CONFIGURATION_DIRECTORY=\"$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\"; & ndc-bigquery.exe serve".to_string(),
+                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\nHASURA_CONFIGURATION_DIRECTORY=\"$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\" \"$HASURA_DDN_NATIVE_CONNECTOR_DIR/ndc-bigquery\" serve".to_string(),
+                        powershell: "$ErrorActionPreference = \"Stop\"\n$env:HASURA_CONFIGURATION_DIRECTORY=\"$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\"; & \"$env:HASURA_DDN_NATIVE_CONNECTOR_DIR\\ndc-bigquery.exe\" serve".to_string(),
                     }),
                     ("update".to_string(), metadata::CommandDefinition::ShellScript {
-                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\n\"$HOME/.ddn/plugins/store/ndc-bigquery/$BIGQUERY_VERSION/hasura-ndc-bigquery\" update".to_string(),
-                        powershell: "$ErrorActionPreference = \"Stop\"\n& \"$env:USERPROFILE\\.ddn\\plugins\\store\\ndc-bigquery\\$env:BIGQUERY_VERSION\\hasura-ndc-bigquery.exe\" update".to_string(),
+                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\n\"$HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR/hasura-ndc-bigquery\" update".to_string(),
+                        powershell: "$ErrorActionPreference = \"Stop\"\n& \"$env:HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR\\hasura-ndc-bigquery.exe\" update".to_string(),
                     }),
                 ].into_iter().collect(),
             })

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -133,6 +133,18 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
                 action: metadata::DockerComposeWatchAction::SyncAndRestart,
                 ignore: vec![],
             }],
+            native_toolchain_definition: Some(metadata::NativeToolchainDefinition {
+                commands: vec![
+                    ("start".to_string(), metadata::CommandDefinition::ShellScript {
+                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\nHASURA_CONFIGURATION_DIRECTORY=\"$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\" ndc-bigquery serve".to_string(),
+                        powershell: "$ErrorActionPreference = \"Stop\"\n$env:HASURA_CONFIGURATION_DIRECTORY=\"$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\"; & ndc-bigquery.exe serve".to_string(),
+                    }),
+                    ("update".to_string(), metadata::CommandDefinition::ShellScript {
+                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\n\"$HOME/.ddn/plugins/store/ndc-bigquery/$BIGQUERY_VERSION/hasura-ndc-bigquery\" update".to_string(),
+                        powershell: "$ErrorActionPreference = \"Stop\"\n& \"$env:USERPROFILE\\.ddn\\plugins\\store\\ndc-bigquery\\$env:BIGQUERY_VERSION\\hasura-ndc-bigquery.exe\" update".to_string(),
+                    }),
+                ].into_iter().collect(),
+            })
         };
 
         fs::write(metadata_file, serde_yaml::to_string(&metadata)?).await?;

--- a/crates/cli/src/metadata.rs
+++ b/crates/cli/src/metadata.rs
@@ -14,6 +14,8 @@ pub struct ConnectorMetadataDefinition {
     pub cli_plugin: Option<CliPluginDefinition>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub docker_compose_watch: DockerComposeWatch,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub native_toolchain_definition: Option<NativeToolchainDefinition>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -74,4 +76,24 @@ pub enum DockerComposeWatchAction {
     Sync,
     #[serde(rename = "sync+restart")]
     SyncAndRestart,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeToolchainDefinition {
+    pub commands: std::collections::BTreeMap<CommandName, CommandDefinition>,
+}
+
+pub type CommandName = String;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase", tag = "type")]
+pub enum CommandDefinition {
+    #[serde(rename_all = "camelCase")]
+    ShellScript { bash: String, powershell: String },
+    #[serde(rename_all = "camelCase")]
+    DockerizedCommand {
+        docker_image: String,
+        command_args: Vec<String>,
+    },
 }

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -1,0 +1,15 @@
+#![allow(dead_code)] // required because this is included mulitple times
+
+use std::path::Path;
+
+use tokio::fs;
+
+pub async fn assert_file_ends_with_newline(path: impl AsRef<Path>) -> anyhow::Result<()> {
+    let contents = fs::read_to_string(path).await?;
+    assert_ends_with_newline(&contents);
+    Ok(())
+}
+
+pub fn assert_ends_with_newline(contents: &str) {
+    assert_eq!(contents.chars().last(), Some('\n'));
+}

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] // required because this is included mulitple times
+#![allow(dead_code)] // required because this is included multiple times
 
 use std::path::Path;
 

--- a/crates/cli/tests/initialize_tests.rs
+++ b/crates/cli/tests/initialize_tests.rs
@@ -1,0 +1,169 @@
+mod common;
+
+use tokio::fs;
+
+use ndc_bigquery_cli::*;
+use ndc_bigquery_configuration as configuration;
+use ndc_bigquery_configuration::ParsedConfiguration;
+
+#[tokio::test]
+async fn test_initialize_directory() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let context = Context {
+        context_path: dir.path().to_owned(),
+        environment: configuration::environment::EmptyEnvironment,
+        release_version: None,
+    };
+    run(
+        Command::Initialize {
+            with_metadata: false,
+        },
+        context,
+    )
+    .await?;
+
+    let configuration_file_path = dir.path().join("configuration.json");
+    assert!(configuration_file_path.exists());
+    let contents = fs::read_to_string(configuration_file_path).await?;
+    common::assert_ends_with_newline(&contents);
+    let _: ParsedConfiguration = configuration::parse_configuration(&dir).await?;
+
+    let metadata_file_path = dir
+        .path()
+        .join(".hasura-connector")
+        .join("connector-metadata.yaml");
+    assert!(!metadata_file_path.exists());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_initialize_version_is_unchanged() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let context = Context {
+        context_path: dir.path().to_owned(),
+        environment: configuration::environment::EmptyEnvironment,
+        release_version: None,
+    };
+    run(
+        Command::Initialize {
+            with_metadata: false,
+        },
+        context,
+    )
+    .await?;
+
+    let configuration_file_path = dir.path().join("configuration.json");
+    assert!(configuration_file_path.exists());
+    let configuration_value: serde_json::Value =
+        serde_json::from_str(fs::read_to_string(configuration_file_path).await?.as_str())?;
+
+    let version = configuration_value
+        .as_object()
+        .unwrap()
+        .get("version")
+        .unwrap();
+
+    insta::assert_snapshot!(version.to_string());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_do_not_initialize_when_files_already_exist() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    fs::write(
+        dir.path().join("random.file"),
+        "this directory is no longer empty",
+    )
+    .await?;
+
+    let context = Context {
+        context_path: dir.path().to_owned(),
+        environment: configuration::environment::EmptyEnvironment,
+        release_version: None,
+    };
+    match run(
+        Command::Initialize {
+            with_metadata: false,
+        },
+        context,
+    )
+    .await
+    {
+        Ok(()) => panic!("Expected the command to fail."),
+        Err(error) => match error.downcast::<Error>() {
+            Err(input) => panic!("Expected a CLI error, but got {input}"),
+            Ok(cli_error) => assert_eq!(cli_error, Error::DirectoryIsNotEmpty),
+        },
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_initialize_directory_with_metadata() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let context = Context {
+        context_path: dir.path().to_owned(),
+        environment: configuration::environment::EmptyEnvironment,
+        release_version: None,
+    };
+    run(
+        Command::Initialize {
+            with_metadata: true,
+        },
+        context,
+    )
+    .await?;
+
+    let configuration_file_path = dir.path().join("configuration.json");
+    assert!(configuration_file_path.exists());
+    common::assert_file_ends_with_newline(&configuration_file_path).await?;
+
+    let metadata_file_path = dir
+        .path()
+        .join(".hasura-connector")
+        .join("connector-metadata.yaml");
+    assert!(metadata_file_path.exists());
+    let contents = fs::read_to_string(metadata_file_path).await?;
+    common::assert_ends_with_newline(&contents);
+    insta::assert_snapshot!(contents);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_initialize_directory_with_metadata_and_release_version() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let context = Context {
+        context_path: dir.path().to_owned(),
+        environment: configuration::environment::EmptyEnvironment,
+        release_version: Some("v1.2.3"),
+    };
+    run(
+        Command::Initialize {
+            with_metadata: true,
+        },
+        context,
+    )
+    .await?;
+
+    let configuration_file_path = dir.path().join("configuration.json");
+    assert!(configuration_file_path.exists());
+    common::assert_file_ends_with_newline(&configuration_file_path).await?;
+
+    let metadata_file_path = dir
+        .path()
+        .join(".hasura-connector")
+        .join("connector-metadata.yaml");
+    assert!(metadata_file_path.exists());
+    let contents = fs::read_to_string(metadata_file_path).await?;
+    common::assert_ends_with_newline(&contents);
+    insta::assert_snapshot!(contents);
+
+    Ok(())
+}

--- a/crates/cli/tests/initialize_tests.rs
+++ b/crates/cli/tests/initialize_tests.rs
@@ -23,6 +23,10 @@ async fn test_initialize_directory() -> anyhow::Result<()> {
     )
     .await?;
 
+    let configuration_schema_file_path = dir.path().join("schema.json");
+    assert!(configuration_schema_file_path.exists());
+    common::assert_file_ends_with_newline(&configuration_schema_file_path).await?;
+
     let configuration_file_path = dir.path().join("configuration.json");
     assert!(configuration_file_path.exists());
     let contents = fs::read_to_string(configuration_file_path).await?;
@@ -119,6 +123,10 @@ async fn test_initialize_directory_with_metadata() -> anyhow::Result<()> {
     )
     .await?;
 
+    let configuration_schema_file_path = dir.path().join("schema.json");
+    assert!(configuration_schema_file_path.exists());
+    common::assert_file_ends_with_newline(&configuration_schema_file_path).await?;
+
     let configuration_file_path = dir.path().join("configuration.json");
     assert!(configuration_file_path.exists());
     common::assert_file_ends_with_newline(&configuration_file_path).await?;
@@ -151,6 +159,10 @@ async fn test_initialize_directory_with_metadata_and_release_version() -> anyhow
         context,
     )
     .await?;
+
+    let configuration_schema_file_path = dir.path().join("schema.json");
+    assert!(configuration_schema_file_path.exists());
+    common::assert_file_ends_with_newline(&configuration_schema_file_path).await?;
 
     let configuration_file_path = dir.path().join("configuration.json");
     assert!(configuration_file_path.exists());

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
@@ -1,0 +1,43 @@
+---
+source: crates/cli/tests/initialize_tests.rs
+expression: contents
+---
+packagingDefinition:
+  type: PrebuiltDockerImage
+  dockerImage: ghcr.io/hasura/ndc-bigquery:latest
+supportedEnvironmentVariables:
+- name: HASURA_BIGQUERY_SERVICE_KEY
+  description: The BigQuery service key
+- name: HASURA_BIGQUERY_PROJECT_ID
+  description: The BigQuery project ID/name
+- name: HASURA_BIGQUERY_DATASET_ID
+  description: The BigQuery dataset ID/name
+commands:
+  update: hasura-ndc-bigquery update
+cliPlugin:
+  name: ndc-bigquery
+  version: latest
+dockerComposeWatch:
+- path: ./
+  target: /etc/connector
+  action: sync+restart
+nativeToolchainDefinition:
+  commands:
+    start:
+      type: ShellScript
+      bash: |-
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" ndc-bigquery serve
+      powershell: |-
+        $ErrorActionPreference = "Stop"
+        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & ndc-bigquery.exe serve
+    update:
+      type: ShellScript
+      bash: |-
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        "$HOME/.ddn/plugins/store/ndc-bigquery/$BIGQUERY_VERSION/hasura-ndc-bigquery" update
+      powershell: |-
+        $ErrorActionPreference = "Stop"
+        & "$env:USERPROFILE\.ddn\plugins\store\ndc-bigquery\$env:BIGQUERY_VERSION\hasura-ndc-bigquery.exe" update

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
@@ -28,16 +28,16 @@ nativeToolchainDefinition:
       bash: |-
         #!/usr/bin/env bash
         set -eu -o pipefail
-        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" ndc-bigquery serve
+        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" "$HASURA_DDN_NATIVE_CONNECTOR_DIR/ndc-bigquery" serve
       powershell: |-
         $ErrorActionPreference = "Stop"
-        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & ndc-bigquery.exe serve
+        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & "$env:HASURA_DDN_NATIVE_CONNECTOR_DIR\ndc-bigquery.exe" serve
     update:
       type: ShellScript
       bash: |-
         #!/usr/bin/env bash
         set -eu -o pipefail
-        "$HOME/.ddn/plugins/store/ndc-bigquery/$BIGQUERY_VERSION/hasura-ndc-bigquery" update
+        "$HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR/hasura-ndc-bigquery" update
       powershell: |-
         $ErrorActionPreference = "Stop"
-        & "$env:USERPROFILE\.ddn\plugins\store\ndc-bigquery\$env:BIGQUERY_VERSION\hasura-ndc-bigquery.exe" update
+        & "$env:HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR\hasura-ndc-bigquery.exe" update

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
@@ -1,0 +1,43 @@
+---
+source: crates/cli/tests/initialize_tests.rs
+expression: contents
+---
+packagingDefinition:
+  type: PrebuiltDockerImage
+  dockerImage: ghcr.io/hasura/ndc-bigquery:v1.2.3
+supportedEnvironmentVariables:
+- name: HASURA_BIGQUERY_SERVICE_KEY
+  description: The BigQuery service key
+- name: HASURA_BIGQUERY_PROJECT_ID
+  description: The BigQuery project ID/name
+- name: HASURA_BIGQUERY_DATASET_ID
+  description: The BigQuery dataset ID/name
+commands:
+  update: hasura-ndc-bigquery update
+cliPlugin:
+  name: ndc-bigquery
+  version: v1.2.3
+dockerComposeWatch:
+- path: ./
+  target: /etc/connector
+  action: sync+restart
+nativeToolchainDefinition:
+  commands:
+    start:
+      type: ShellScript
+      bash: |-
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" ndc-bigquery serve
+      powershell: |-
+        $ErrorActionPreference = "Stop"
+        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & ndc-bigquery.exe serve
+    update:
+      type: ShellScript
+      bash: |-
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        "$HOME/.ddn/plugins/store/ndc-bigquery/$BIGQUERY_VERSION/hasura-ndc-bigquery" update
+      powershell: |-
+        $ErrorActionPreference = "Stop"
+        & "$env:USERPROFILE\.ddn\plugins\store\ndc-bigquery\$env:BIGQUERY_VERSION\hasura-ndc-bigquery.exe" update

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
@@ -28,16 +28,16 @@ nativeToolchainDefinition:
       bash: |-
         #!/usr/bin/env bash
         set -eu -o pipefail
-        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" ndc-bigquery serve
+        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" "$HASURA_DDN_NATIVE_CONNECTOR_DIR/ndc-bigquery" serve
       powershell: |-
         $ErrorActionPreference = "Stop"
-        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & ndc-bigquery.exe serve
+        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & "$env:HASURA_DDN_NATIVE_CONNECTOR_DIR\ndc-bigquery.exe" serve
     update:
       type: ShellScript
       bash: |-
         #!/usr/bin/env bash
         set -eu -o pipefail
-        "$HOME/.ddn/plugins/store/ndc-bigquery/$BIGQUERY_VERSION/hasura-ndc-bigquery" update
+        "$HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR/hasura-ndc-bigquery" update
       powershell: |-
         $ErrorActionPreference = "Stop"
-        & "$env:USERPROFILE\.ddn\plugins\store\ndc-bigquery\$env:BIGQUERY_VERSION\hasura-ndc-bigquery.exe" update
+        & "$env:HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR\hasura-ndc-bigquery.exe" update

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_version_is_unchanged.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_version_is_unchanged.snap
@@ -1,0 +1,5 @@
+---
+source: crates/cli/tests/initialize_tests.rs
+expression: version.to_string()
+---
+1


### PR DESCRIPTION
This PR adds native toolchains in ndc-bigquery.

It also adds CLI snapshot tests (similar to what we have in ndc-postgres).
![image](https://github.com/user-attachments/assets/12584e1e-5b8f-474e-8a57-7763a508bb20)


### What

<!-- What is this PR trying to accomplish (and why, if it's not obvious)? -->

This PR adds the native toolchain definition to the connector metadata.

It also adds two commands in the initial metadata generated by the CLI:
```yaml
nativeToolchainDefinition:
  commands:
    start:
      type: ShellScript
      bash: |-
        #!/usr/bin/env bash
        set -eu -o pipefail
        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" "$HASURA_DDN_NATIVE_CONNECTOR_DIR/ndc-bigquery" serve
      powershell: |-
        $ErrorActionPreference = "Stop"
        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & "$env:HASURA_DDN_NATIVE_CONNECTOR_DIR\ndc-bigquery.exe" serve
    update:
      type: ShellScript
      bash: |-
        #!/usr/bin/env bash
        set -eu -o pipefail
        "$HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR/hasura-ndc-bigquery" update
      powershell: |-
        $ErrorActionPreference = "Stop"
        & "$env:HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR\hasura-ndc-bigquery.exe" update
```

<details>
<summary>Click here for the CLI command output</summary>

```
❯ mkdir test; cd test; ndc-bigquery-cli initialize --with-metadata
❯ cat .hasura-connector/connector-metadata.yaml
packagingDefinition:
  type: PrebuiltDockerImage
  dockerImage: ghcr.io/hasura/ndc-bigquery:latest
supportedEnvironmentVariables:
- name: HASURA_BIGQUERY_SERVICE_KEY
  description: The BigQuery service key
- name: HASURA_BIGQUERY_PROJECT_ID
  description: The BigQuery project ID/name
- name: HASURA_BIGQUERY_DATASET_ID
  description: The BigQuery dataset ID/name
commands:
  update: hasura-ndc-bigquery update
cliPlugin:
  name: ndc-bigquery
  version: latest
dockerComposeWatch:
- path: ./
  target: /etc/connector
  action: sync+restart
nativeToolchainDefinition:
  commands:
    start:
      type: ShellScript
      bash: |-
        #!/usr/bin/env bash
        set -eu -o pipefail
        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" "$HASURA_DDN_NATIVE_CONNECTOR_DIR/ndc-bigquery" serve
      powershell: |-
        $ErrorActionPreference = "Stop"
        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & "$env:HASURA_DDN_NATIVE_CONNECTOR_DIR\ndc-bigquery.exe" serve
    update:
      type: ShellScript
      bash: |-
        #!/usr/bin/env bash
        set -eu -o pipefail
        "$HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR/hasura-ndc-bigquery" update
      powershell: |-
        $ErrorActionPreference = "Stop"
        & "$env:HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR\hasura-ndc-bigquery.exe" update
```

</details>

### How

<!-- How is it trying to accomplish it (what are the implementation steps)? -->
