### PR TITLE
Remove gokakashi checks

### DIFF
--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -34,27 +34,6 @@ jobs:
       - name: Build a Docker image with Nix
         run: nix build --print-build-logs '.#docker-${{ matrix.target }}'
 
-      - name: Load and get Docker image
-        id: load-image
-        run: |
-          # Load the image and capture its name
-          LOADED_IMAGE=$(docker load < result | awk -F': ' '{print $2}')
-          echo "image=$LOADED_IMAGE" >> $GITHUB_OUTPUT
-          echo "Loaded image: $LOADED_IMAGE"
-      - name: Scan Docker Image with gokakashi
-        uses: shinobistack/gokakashi-action@v0.2.0
-        with:
-          image: ${{ steps.load-image.outputs.image }}
-          labels: agentKey=${{ github.run_id }}-${{ matrix.target }}
-          policy: ci-platform
-          server: https://gokakashi-server.hasura-app.io
-          token: ${{ secrets.GOKAKASHI_API_TOKEN }}
-          cf_client_id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          cf_client_secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
-          interval: 10
-          retries: 8
-          timeout: 30m
-
       # scream into Slack if something goes wrong
       - name: Report Status
         if: always() && github.ref == 'refs/heads/main'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,10 +463,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -1293,6 +1294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,6 +1567,12 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2424,14 +2437,16 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
+ "num-conv",
  "num_threads",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -2439,16 +2454,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.80.0"
 profile = "default"  # see https://rust-lang.github.io/rustup/concepts/profiles.html
 components = ["rust-analyzer", "rust-src"]  # see https://rust-lang.github.io/rustup/concepts/components.html


### PR DESCRIPTION
These are broken, and these checks now happen centrally in `ndc-hub`, so removing them. Then we had to bump `rustc` to fix `cargo machete`, then we had to bump `time` to keep everything building.